### PR TITLE
fix an issue with multilevel flattening on Device Template VPN templates

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
   edge_feature_templates = try(local.model.sdwan.edge_feature_templates, {})
-  cedge_device_templates = try(local.model.sdwan.cedge_device_templates, {})
+  edge_device_templates  = try(local.model.sdwan.edge_device_templates, {})
   localized_policies     = try(local.model.sdwan.localized_policies, {})
   policy_objects         = try(local.model.sdwan.policy_objects, {})
   sites                  = try(local.model.sdwan.sites, {})

--- a/sdwan_device_templates.tf
+++ b/sdwan_device_templates.tf
@@ -1,58 +1,199 @@
 resource "sdwan_feature_device_template" "feature_device_template" {
-  for_each       = { for t in try(local.cedge_device_templates.device_template, {}) : t.name => t }
+  for_each       = { for t in try(local.edge_device_templates, {}) : t.name => t }
   name           = each.value.name
   description    = each.value.description
-  device_type    = try(local.device_type_map[each.value.parameters.device_model], "vedge-${each.value.parameters.device_model}")
-  policy_id      = try(sdwan_localized_policy.localized_policy[each.value.parameters.localized_policy].id, null)
-  policy_version = try(sdwan_localized_policy.localized_policy[each.value.parameters.localized_policy].version, null)
-  general_templates = try(length(each.value.parameters.feature_templates) == 0, true) ? null : [for ft in each.value.parameters.feature_templates : {
-    id = (
-      ft.templateType == "cedge_aaa" ? sdwan_cedge_aaa_feature_template.cedge_aaa_feature_template[ft.templateName].id :
-      ft.templateType == "cedge_global" ? sdwan_cedge_global_feature_template.cedge_global_feature_template[ft.templateName].id :
-      ft.templateType == "cisco_banner" ? sdwan_cisco_banner_feature_template.cisco_banner_feature_template[ft.templateName].id :
-      ft.templateType == "cisco_bfd" ? sdwan_cisco_bfd_feature_template.cisco_bfd_feature_template[ft.templateName].id :
-      ft.templateType == "cisco_omp" ? sdwan_cisco_omp_feature_template.cisco_omp_feature_template[ft.templateName].id :
-      ft.templateType == "cisco_security" ? sdwan_cisco_security_feature_template.cisco_security_feature_template[ft.templateName].id :
-      ft.templateType == "cisco_sig_credentials" ? sdwan_cisco_sig_credentials_feature_template.cisco_sig_credentials_feature_template[ft.templateName].id :
-      ft.templateType == "cisco_snmp" ? sdwan_cisco_snmp_feature_template.cisco_snmp_feature_template[ft.templateName].id :
-      ft.templateType == "cisco_system" ? sdwan_cisco_system_feature_template.cisco_system_feature_template[ft.templateName].id :
-      ft.templateType == "cisco_vpn" ? sdwan_cisco_vpn_feature_template.cisco_vpn_feature_template[ft.templateName].id :
-      ft.templateType == "cli-template" ? sdwan_cli_template_feature_template.cli_template_feature_template[ft.templateName].id : null
-    )
-    version = (
-      ft.templateType == "cedge_aaa" ? sdwan_cedge_aaa_feature_template.cedge_aaa_feature_template[ft.templateName].version :
-      ft.templateType == "cedge_global" ? sdwan_cedge_global_feature_template.cedge_global_feature_template[ft.templateName].version :
-      ft.templateType == "cisco_banner" ? sdwan_cisco_banner_feature_template.cisco_banner_feature_template[ft.templateName].version :
-      ft.templateType == "cisco_bfd" ? sdwan_cisco_bfd_feature_template.cisco_bfd_feature_template[ft.templateName].version :
-      ft.templateType == "cisco_omp" ? sdwan_cisco_omp_feature_template.cisco_omp_feature_template[ft.templateName].version :
-      ft.templateType == "cisco_security" ? sdwan_cisco_security_feature_template.cisco_security_feature_template[ft.templateName].version :
-      ft.templateType == "cisco_sig_credentials" ? sdwan_cisco_sig_credentials_feature_template.cisco_sig_credentials_feature_template[ft.templateName].version :
-      ft.templateType == "cisco_snmp" ? sdwan_cisco_snmp_feature_template.cisco_snmp_feature_template[ft.templateName].version :
-      ft.templateType == "cisco_system" ? sdwan_cisco_system_feature_template.cisco_system_feature_template[ft.templateName].version :
-      ft.templateType == "cisco_vpn" ? sdwan_cisco_vpn_feature_template.cisco_vpn_feature_template[ft.templateName].version :
-      ft.templateType == "cli-template" ? sdwan_cli_template_feature_template.cli_template_feature_template[ft.templateName].version : null
-    )
-    type = ft.templateType
-    sub_templates = try(length(ft.subTemplates) == 0, true) ? null : [for st in ft.subTemplates : {
-      id = (
-        st.templateType == "cisco_bgp" ? sdwan_cisco_bgp_feature_template.cisco_bgp_feature_template[st.templateName].id :
-        st.templateType == "cisco_ospf" ? sdwan_cisco_ospf_feature_template.cisco_ospf_feature_template[st.templateName].id :
-        st.templateType == "cisco_ntp" ? sdwan_cisco_ntp_feature_template.cisco_ntp_feature_template[st.templateName].id :
-        st.templateType == "cisco_logging" ? sdwan_cisco_logging_feature_template.cisco_logging_feature_template[st.templateName].id :
-        st.templateType == "cisco_vpn_interface" ? sdwan_cisco_vpn_interface_feature_template.cisco_vpn_interface_feature_template[st.templateName].id : null
-      )
-      version = (
-        st.templateType == "cisco_bgp" ? sdwan_cisco_bgp_feature_template.cisco_bgp_feature_template[st.templateName].version :
-        st.templateType == "cisco_ospf" ? sdwan_cisco_ospf_feature_template.cisco_ospf_feature_template[st.templateName].version :
-        st.templateType == "cisco_ntp" ? sdwan_cisco_ntp_feature_template.cisco_ntp_feature_template[st.templateName].version :
-        st.templateType == "cisco_logging" ? sdwan_cisco_logging_feature_template.cisco_logging_feature_template[st.templateName].version :
-        st.templateType == "cisco_vpn_interface" ? sdwan_cisco_vpn_interface_feature_template.cisco_vpn_interface_feature_template[st.templateName].version : null
-      )
-      type = st.templateType
-    }]
-  }]
+  device_type    = try(local.device_type_map[each.value.device_model], "vedge-${each.value.device_model}")
+  policy_id      = sdwan_localized_policy.localized_policy[each.value.localized_policy].id
+  policy_version = sdwan_localized_policy.localized_policy[each.value.localized_policy].version
+  general_templates = flatten([
+    try(each.value.system_template, null) == null ? [] : [{
+      id      = sdwan_cisco_system_feature_template.cisco_system_feature_template[each.value.system_template].id
+      version = sdwan_cisco_system_feature_template.cisco_system_feature_template[each.value.system_template].version
+      type    = "cisco_system"
+      sub_templates = flatten([
+        try(each.value.logging_template, null) == null ? [] : [{
+          id      = sdwan_cisco_logging_feature_template.cisco_logging_feature_template[each.value.logging_template].id
+          version = sdwan_cisco_logging_feature_template.cisco_logging_feature_template[each.value.logging_template].version
+          type    = "cisco_logging"
+        }],
+        try(each.value.ntp_template, null) == null ? [] : [{
+          id      = sdwan_cisco_ntp_feature_template.cisco_ntp_feature_template[each.value.ntp_template].id
+          version = sdwan_cisco_ntp_feature_template.cisco_ntp_feature_template[each.value.ntp_template].version
+          type    = "cisco_ntp"
+        }]
+      ])
+    }],
+    try(each.value.aaa_template, null) == null ? [] : [{
+      id      = sdwan_cedge_aaa_feature_template.cedge_aaa_feature_template[each.value.aaa_template].id
+      version = sdwan_cedge_aaa_feature_template.cedge_aaa_feature_template[each.value.aaa_template].version
+      type    = "cedge_aaa"
+    }],
+    try(each.value.bfd_template, null) == null ? [] : [{
+      id      = sdwan_cisco_bfd_feature_template.cisco_bfd_feature_template[each.value.bfd_template].id
+      version = sdwan_cisco_bfd_feature_template.cisco_bfd_feature_template[each.value.bfd_template].version
+      type    = "cisco_bfd"
+    }],
+    try(each.value.omp_template, null) == null ? [] : [{
+      id      = sdwan_cisco_omp_feature_template.cisco_omp_feature_template[each.value.omp_template].id
+      version = sdwan_cisco_omp_feature_template.cisco_omp_feature_template[each.value.omp_template].version
+      type    = "cisco_omp"
+    }],
+    try(each.value.security_template, null) == null ? [] : [{
+      id      = sdwan_cisco_security_feature_template.cisco_security_feature_template[each.value.security_template].id
+      version = sdwan_cisco_security_feature_template.cisco_security_feature_template[each.value.security_template].version
+      type    = "cisco_security"
+    }],
+    try(each.value.banner_template, null) == null ? [] : [{
+      id      = sdwan_cisco_banner_feature_template.cisco_banner_feature_template[each.value.banner_template].id
+      version = sdwan_cisco_banner_feature_template.cisco_banner_feature_template[each.value.banner_template].version
+      type    = "cisco_banner"
+    }],
+    try(each.value.snmp_template, null) == null ? [] : [{
+      id      = sdwan_cisco_snmp_feature_template.cisco_snmp_feature_template[each.value.snmp_template].id
+      version = sdwan_cisco_snmp_feature_template.cisco_snmp_feature_template[each.value.snmp_template].version
+      type    = "cisco_snmp"
+    }],
+    try(each.value.global_settings_template, null) == null ? [] : [{
+      id      = sdwan_cedge_global_feature_template.cedge_global_feature_template[each.value.global_settings_template].id
+      version = sdwan_cedge_global_feature_template.cedge_global_feature_template[each.value.global_settings_template].version
+      type    = "cedge_global"
+    }],
+    try(each.value.cli_template, null) == null ? [] : [{
+      id      = sdwan_cli_template_feature_template.cli_template_feature_template[each.value.cli_template].id
+      version = sdwan_cli_template_feature_template.cli_template_feature_template[each.value.cli_template].version
+      type    = "cli-template"
+    }],
+    try(each.value.vpn_0_template.sig_credentials_template, null) == null ? [] : [{
+      id      = sdwan_cisco_sig_credentials_feature_template.cisco_sig_credentials_feature_template[each.value.vpn_0_template.sig_credentials_template].id
+      version = sdwan_cisco_sig_credentials_feature_template.cisco_sig_credentials_feature_template[each.value.vpn_0_template.sig_credentials_template].version
+      type    = "cisco_sig_credentials"
+    }],
+    try(each.value.switchport_templates, null) == null ? [] : [for spt in try(each.value.switchport_templates, []) : {
+      id      = sdwan_switchport_feature_template.switchport_feature_template[spt.name].id
+      version = sdwan_switchport_feature_template.switchport_feature_template[spt.name].version
+      type    = "switchport"
+    }],
+    try(each.value.thousandeyes_template, null) == null ? [] : [{
+      id      = sdwan_cisco_thousandeyes_feature_template.cisco_thousandeyes_feature_template[each.value.thousandeyes_template].id
+      version = sdwan_cisco_thousandeyes_feature_template.cisco_thousandeyes_feature_template[each.value.thousandeyes_template].version
+      type    = "cisco_thousandeyes"
+    }],
+    try(each.value.vpn_0_template, null) == null ? [] : [{
+      id      = sdwan_cisco_vpn_feature_template.cisco_vpn_feature_template[each.value.vpn_0_template.name].id
+      version = sdwan_cisco_vpn_feature_template.cisco_vpn_feature_template[each.value.vpn_0_template.name].version
+      type    = "cisco_vpn"
+      sub_templates = flatten([
+        try(each.value.vpn_0_template.ospf_template, null) == null ? [] : [{
+          id      = sdwan_cisco_ospf_feature_template.cisco_ospf_feature_template[each.value.vpn_0_template.ospf_template].id
+          version = sdwan_cisco_ospf_feature_template.cisco_ospf_feature_template[each.value.vpn_0_template.ospf_template].version
+          type    = "cisco_ospf"
+        }],
+        try(each.value.vpn_0_template.bgp_template, null) == null ? [] : [{
+          id      = sdwan_cisco_bgp_feature_template.cisco_bgp_feature_template[each.value.vpn_0_template.bgp_template].id
+          version = sdwan_cisco_bgp_feature_template.cisco_bgp_feature_template[each.value.vpn_0_template.bgp_template].version
+          type    = "cisco_bgp"
+        }],
+        try(each.value.vpn_0_template.ethernet_interface_templates, null) == null ? [] : [for eit in try(each.value.vpn_0_template.ethernet_interface_templates, []) : {
+          id      = sdwan_cisco_vpn_interface_feature_template.cisco_vpn_interface_feature_template[eit.name].id
+          version = sdwan_cisco_vpn_interface_feature_template.cisco_vpn_interface_feature_template[eit.name].version
+          type    = "cisco_vpn_interface"
+        }],
+        try(each.value.vpn_0_template.ipsec_interface_templates, null) == null ? [] : [for iit in try(each.value.vpn_0_template.ipsec_interface_templates, []) : {
+          id      = sdwan_cisco_vpn_interface_ipsec_feature_template.cisco_vpn_interface_ipsec_feature_template[iit.name].id
+          version = sdwan_cisco_vpn_interface_ipsec_feature_template.cisco_vpn_interface_ipsec_feature_template[iit.name].version
+          type    = "cisco_vpn_interface_ipsec"
+          sub_templates = flatten([
+            try(iit.dhcp_server_template, null) == null ? [] : [{
+              id      = sdwan_cisco_dhcp_server_feature_template.cisco_dhcp_server_feature_template[iit.dhcp_server_template].id
+              version = sdwan_cisco_dhcp_server_feature_template.cisco_dhcp_server_feature_template[iit.dhcp_server_template].version
+              type    = "cisco_dhcp_server"
+            }],
+          ])
+        }],
+        try(each.value.vpn_0_template.svi_interface_templates, null) == null ? [] : [for sit in try(each.value.vpn_0_template.svi_interface_templates, []) : {
+          id      = sdwan_vpn_interface_svi_feature_template.vpn_interface_svi_feature_template[sit.name].id
+          version = sdwan_vpn_interface_svi_feature_template.vpn_interface_svi_feature_template[sit.name].version
+          type    = "vpn-interface-svi"
+        }],
+        try(each.value.vpn_0_template.secure_internet_gateway_template, null) == null ? [] : [{
+          id      = sdwan_cisco_secure_internet_gateway_feature_template.cisco_secure_internet_gateway_feature_template[each.value.vpn_0_template.secure_internet_gateway_template].id
+          version = sdwan_cisco_secure_internet_gateway_feature_template.cisco_secure_internet_gateway_feature_template[each.value.vpn_0_template.secure_internet_gateway_template].version
+          type    = "cisco_secure_internet_gateway"
+        }],
+      ])
+    }],
+    try(each.value.vpn_512_template, null) == null ? [] : [{
+      id      = sdwan_cisco_vpn_feature_template.cisco_vpn_feature_template[each.value.vpn_512_template.name].id
+      version = sdwan_cisco_vpn_feature_template.cisco_vpn_feature_template[each.value.vpn_512_template.name].version
+      type    = "cisco_vpn"
+      sub_templates = flatten([
+        try(each.value.vpn_512_template.ethernet_interface_templates, null) == null ? [] : [for eit in try(each.value.vpn_512_template.ethernet_interface_templates, []) : {
+          id      = sdwan_cisco_vpn_interface_feature_template.cisco_vpn_interface_feature_template[eit.name].id
+          version = sdwan_cisco_vpn_interface_feature_template.cisco_vpn_interface_feature_template[eit.name].version
+          type    = "cisco_vpn_interface"
+        }],
+        try(each.value.vpn_512_template.svi_interface_templates, null) == null ? [] : [for sit in try(each.value.vpn_512_template.svi_interface_templates, []) : {
+          id      = sdwan_vpn_interface_svi_feature_template.vpn_interface_svi_feature_template[sit.name].id
+          version = sdwan_vpn_interface_svi_feature_template.vpn_interface_svi_feature_template[sit.name].version
+          type    = "vpn-interface-svi"
+        }],
+      ])
+    }],
+    try(each.value.vpn_service_templates, null) == null ? [] : [for st in try(each.value.vpn_service_templates, []) : {
+      id      = sdwan_cisco_vpn_feature_template.cisco_vpn_feature_template[st.name].id
+      version = sdwan_cisco_vpn_feature_template.cisco_vpn_feature_template[st.name].version
+      type    = "cisco_vpn"
+      sub_templates = flatten([
+        try(st.ospf_template, null) == null ? [] : [{
+          id      = sdwan_cisco_ospf_feature_template.cisco_ospf_feature_template[st.ospf_template].id
+          version = sdwan_cisco_ospf_feature_template.cisco_ospf_feature_template[st.ospf_template].version
+          type    = "cisco_ospf"
+        }],
+        try(st.bgp_template, null) == null ? [] : [{
+          id      = sdwan_cisco_bgp_feature_template.cisco_bgp_feature_template[st.bgp_template].id
+          version = sdwan_cisco_bgp_feature_template.cisco_bgp_feature_template[st.bgp_template].version
+          type    = "cisco_bgp"
+        }],
+        try(st.ethernet_interface_templates, null) == null ? [] : [for eit in try(st.ethernet_interface_templates, []) : {
+          id      = sdwan_cisco_vpn_interface_feature_template.cisco_vpn_interface_feature_template[eit.name].id
+          version = sdwan_cisco_vpn_interface_feature_template.cisco_vpn_interface_feature_template[eit.name].version
+          type    = "cisco_vpn_interface"
+          sub_templates = flatten([
+            try(eit.dhcp_server_template, null) == null ? [] : [{
+              id      = sdwan_cisco_dhcp_server_feature_template.cisco_dhcp_server_feature_template[eit.dhcp_server_template].id
+              version = sdwan_cisco_dhcp_server_feature_template.cisco_dhcp_server_feature_template[eit.dhcp_server_template].version
+              type    = "cisco_dhcp_server"
+            }],
+          ])
+        }],
+        try(st.ipsec_interface_templates, null) == null ? [] : [for iit in try(st.ipsec_interface_templates, []) : {
+          id      = sdwan_cisco_vpn_interface_ipsec_feature_template.cisco_vpn_interface_ipsec_feature_template[iit.name].id
+          version = sdwan_cisco_vpn_interface_ipsec_feature_template.cisco_vpn_interface_ipsec_feature_template[iit.name].version
+          type    = "cisco_vpn_interface_ipsec"
+          sub_templates = flatten([
+            try(iit.dhcp_server_template, null) == null ? [] : [{
+              id      = sdwan_cisco_dhcp_server_feature_template.cisco_dhcp_server_feature_template[iit.dhcp_server_template].id
+              version = sdwan_cisco_dhcp_server_feature_template.cisco_dhcp_server_feature_template[iit.dhcp_server_template].version
+              type    = "cisco_dhcp_server"
+            }],
+          ])
+        }],
+        try(st.svi_interface_templates, null) == null ? [] : [for sit in try(st.svi_interface_templates, []) : {
+          id      = sdwan_vpn_interface_svi_feature_template.vpn_interface_svi_feature_template[sit.name].id
+          version = sdwan_vpn_interface_svi_feature_template.vpn_interface_svi_feature_template[sit.name].version
+          type    = "vpn-interface-svi"
+          sub_templates = flatten([
+            try(sit.dhcp_server_template, null) == null ? [] : [{
+              id      = sdwan_cisco_dhcp_server_feature_template.cisco_dhcp_server_feature_template[sit.dhcp_server_template].id
+              version = sdwan_cisco_dhcp_server_feature_template.cisco_dhcp_server_feature_template[sit.dhcp_server_template].version
+              type    = "cisco_dhcp_server"
+            }],
+          ])
+        }],
+      ])
+    }],
+  ])
 }
-
 
 locals {
   routers = flatten([

--- a/sdwan_device_templates.tf
+++ b/sdwan_device_templates.tf
@@ -139,7 +139,7 @@ resource "sdwan_feature_device_template" "feature_device_template" {
         }],
       ])
     }],
-    try(each.value.vpn_service_templates, null) == null ? try([for ss in try(each.value.vpn_service_templates,[]) : null], []) : [for st in try(each.value.vpn_service_templates, []) : {
+    try(each.value.vpn_service_templates, null) == null ? try([for ss in try(each.value.vpn_service_templates, []) : null], []) : [for st in try(each.value.vpn_service_templates, []) : {
       id      = sdwan_cisco_vpn_feature_template.cisco_vpn_feature_template[st.name].id
       version = sdwan_cisco_vpn_feature_template.cisco_vpn_feature_template[st.name].version
       type    = "cisco_vpn"
@@ -159,30 +159,30 @@ resource "sdwan_feature_device_template" "feature_device_template" {
           version = sdwan_cisco_vpn_interface_feature_template.cisco_vpn_interface_feature_template[eit.name].version
           type    = "cisco_vpn_interface"
           sub_templates = try(eit.dhcp_server_template, null) == null ? [] : [{
-              id      = sdwan_cisco_dhcp_server_feature_template.cisco_dhcp_server_feature_template[eit.dhcp_server_template].id
-              version = sdwan_cisco_dhcp_server_feature_template.cisco_dhcp_server_feature_template[eit.dhcp_server_template].version
-              type    = "cisco_dhcp_server"
-            }]
+            id      = sdwan_cisco_dhcp_server_feature_template.cisco_dhcp_server_feature_template[eit.dhcp_server_template].id
+            version = sdwan_cisco_dhcp_server_feature_template.cisco_dhcp_server_feature_template[eit.dhcp_server_template].version
+            type    = "cisco_dhcp_server"
+          }]
         }],
         try(st.ipsec_interface_templates, null) == null ? [] : [for iit in try(st.ipsec_interface_templates, []) : {
           id      = sdwan_cisco_vpn_interface_ipsec_feature_template.cisco_vpn_interface_ipsec_feature_template[iit.name].id
           version = sdwan_cisco_vpn_interface_ipsec_feature_template.cisco_vpn_interface_ipsec_feature_template[iit.name].version
           type    = "cisco_vpn_interface_ipsec"
           sub_templates = try(iit.dhcp_server_template, null) == null ? [] : [{
-              id      = sdwan_cisco_dhcp_server_feature_template.cisco_dhcp_server_feature_template[iit.dhcp_server_template].id
-              version = sdwan_cisco_dhcp_server_feature_template.cisco_dhcp_server_feature_template[iit.dhcp_server_template].version
-              type    = "cisco_dhcp_server"
-            }]
+            id      = sdwan_cisco_dhcp_server_feature_template.cisco_dhcp_server_feature_template[iit.dhcp_server_template].id
+            version = sdwan_cisco_dhcp_server_feature_template.cisco_dhcp_server_feature_template[iit.dhcp_server_template].version
+            type    = "cisco_dhcp_server"
+          }]
         }],
         try(st.svi_interface_templates, null) == null ? [] : [for sit in try(st.svi_interface_templates, []) : {
           id      = sdwan_vpn_interface_svi_feature_template.vpn_interface_svi_feature_template[sit.name].id
           version = sdwan_vpn_interface_svi_feature_template.vpn_interface_svi_feature_template[sit.name].version
           type    = "vpn-interface-svi"
           sub_templates = try(sit.dhcp_server_template, null) == null ? [] : [{
-              id      = sdwan_cisco_dhcp_server_feature_template.cisco_dhcp_server_feature_template[sit.dhcp_server_template].id
-              version = sdwan_cisco_dhcp_server_feature_template.cisco_dhcp_server_feature_template[sit.dhcp_server_template].version
-              type    = "cisco_dhcp_server"
-            }],
+            id      = sdwan_cisco_dhcp_server_feature_template.cisco_dhcp_server_feature_template[sit.dhcp_server_template].id
+            version = sdwan_cisco_dhcp_server_feature_template.cisco_dhcp_server_feature_template[sit.dhcp_server_template].version
+            type    = "cisco_dhcp_server"
+          }],
         }],
       ])
     }],

--- a/sdwan_device_templates.tf
+++ b/sdwan_device_templates.tf
@@ -139,7 +139,7 @@ resource "sdwan_feature_device_template" "feature_device_template" {
         }],
       ])
     }],
-    try(each.value.vpn_service_templates, null) == null ? [] : [for st in try(each.value.vpn_service_templates, []) : {
+    try(each.value.vpn_service_templates, null) == null ? null : [for st in try(each.value.vpn_service_templates, []) : {
       id      = sdwan_cisco_vpn_feature_template.cisco_vpn_feature_template[st.name].id
       version = sdwan_cisco_vpn_feature_template.cisco_vpn_feature_template[st.name].version
       type    = "cisco_vpn"

--- a/sdwan_device_templates.tf
+++ b/sdwan_device_templates.tf
@@ -102,13 +102,11 @@ resource "sdwan_feature_device_template" "feature_device_template" {
           id      = sdwan_cisco_vpn_interface_ipsec_feature_template.cisco_vpn_interface_ipsec_feature_template[iit.name].id
           version = sdwan_cisco_vpn_interface_ipsec_feature_template.cisco_vpn_interface_ipsec_feature_template[iit.name].version
           type    = "cisco_vpn_interface_ipsec"
-          sub_templates = flatten([
-            try(iit.dhcp_server_template, null) == null ? [] : [{
+          sub_templates = try(iit.dhcp_server_template, null) == null ? [] : [{
               id      = sdwan_cisco_dhcp_server_feature_template.cisco_dhcp_server_feature_template[iit.dhcp_server_template].id
               version = sdwan_cisco_dhcp_server_feature_template.cisco_dhcp_server_feature_template[iit.dhcp_server_template].version
               type    = "cisco_dhcp_server"
-            }],
-          ])
+            }]
         }],
         try(each.value.vpn_0_template.svi_interface_templates, null) == null ? [] : [for sit in try(each.value.vpn_0_template.svi_interface_templates, []) : {
           id      = sdwan_vpn_interface_svi_feature_template.vpn_interface_svi_feature_template[sit.name].id
@@ -154,42 +152,36 @@ resource "sdwan_feature_device_template" "feature_device_template" {
           version = sdwan_cisco_bgp_feature_template.cisco_bgp_feature_template[st.bgp_template].version
           type    = "cisco_bgp"
         }],
-        try(st.ethernet_interface_templates, null) == null ? [] : [for eit in try(st.ethernet_interface_templates, []) : {
+        try(st.ethernet_interface_templates, null) == null ? [] : [for eit in try(st.ethernet_interface_templates, []) : [{
           id      = sdwan_cisco_vpn_interface_feature_template.cisco_vpn_interface_feature_template[eit.name].id
           version = sdwan_cisco_vpn_interface_feature_template.cisco_vpn_interface_feature_template[eit.name].version
           type    = "cisco_vpn_interface"
-          sub_templates = flatten([
-            try(eit.dhcp_server_template, null) == null ? [] : [{
+          sub_templates = try(eit.dhcp_server_template, null) == null ? [] : [{
               id      = sdwan_cisco_dhcp_server_feature_template.cisco_dhcp_server_feature_template[eit.dhcp_server_template].id
               version = sdwan_cisco_dhcp_server_feature_template.cisco_dhcp_server_feature_template[eit.dhcp_server_template].version
               type    = "cisco_dhcp_server"
-            }],
-          ])
-        }],
-        try(st.ipsec_interface_templates, null) == null ? [] : [for iit in try(st.ipsec_interface_templates, []) : {
+            }]
+        }]],
+        try(st.ipsec_interface_templates, null) == null ? [] : [for iit in try(st.ipsec_interface_templates, []) : [{
           id      = sdwan_cisco_vpn_interface_ipsec_feature_template.cisco_vpn_interface_ipsec_feature_template[iit.name].id
           version = sdwan_cisco_vpn_interface_ipsec_feature_template.cisco_vpn_interface_ipsec_feature_template[iit.name].version
           type    = "cisco_vpn_interface_ipsec"
-          sub_templates = flatten([
-            try(iit.dhcp_server_template, null) == null ? [] : [{
+          sub_templates = try(iit.dhcp_server_template, null) == null ? [] : [{
               id      = sdwan_cisco_dhcp_server_feature_template.cisco_dhcp_server_feature_template[iit.dhcp_server_template].id
               version = sdwan_cisco_dhcp_server_feature_template.cisco_dhcp_server_feature_template[iit.dhcp_server_template].version
               type    = "cisco_dhcp_server"
-            }],
-          ])
-        }],
-        try(st.svi_interface_templates, null) == null ? [] : [for sit in try(st.svi_interface_templates, []) : {
+            }]
+        }]],
+        try(st.svi_interface_templates, null) == null ? [] : [for sit in try(st.svi_interface_templates, []) : [{
           id      = sdwan_vpn_interface_svi_feature_template.vpn_interface_svi_feature_template[sit.name].id
           version = sdwan_vpn_interface_svi_feature_template.vpn_interface_svi_feature_template[sit.name].version
           type    = "vpn-interface-svi"
-          sub_templates = flatten([
-            try(sit.dhcp_server_template, null) == null ? [] : [{
+          sub_templates = try(sit.dhcp_server_template, null) == null ? [] : [{
               id      = sdwan_cisco_dhcp_server_feature_template.cisco_dhcp_server_feature_template[sit.dhcp_server_template].id
               version = sdwan_cisco_dhcp_server_feature_template.cisco_dhcp_server_feature_template[sit.dhcp_server_template].version
               type    = "cisco_dhcp_server"
-            }],
-          ])
-        }],
+            }]
+        }]],
       ])
     }],
   ])

--- a/sdwan_device_templates.tf
+++ b/sdwan_device_templates.tf
@@ -3,8 +3,8 @@ resource "sdwan_feature_device_template" "feature_device_template" {
   name           = each.value.name
   description    = each.value.description
   device_type    = try(local.device_type_map[each.value.device_model], "vedge-${each.value.device_model}")
-  policy_id      = sdwan_localized_policy.localized_policy[each.value.localized_policy].id
-  policy_version = sdwan_localized_policy.localized_policy[each.value.localized_policy].version
+  policy_id      = try(each.value.localized_policy, null) == null ? null : sdwan_localized_policy.localized_policy[each.value.localized_policy].id
+  policy_version = try(each.value.localized_policy, null) == null ? null : sdwan_localized_policy.localized_policy[each.value.localized_policy].version
   general_templates = flatten([
     try(each.value.system_template, null) == null ? [] : [{
       id      = sdwan_cisco_system_feature_template.cisco_system_feature_template[each.value.system_template].id
@@ -102,11 +102,13 @@ resource "sdwan_feature_device_template" "feature_device_template" {
           id      = sdwan_cisco_vpn_interface_ipsec_feature_template.cisco_vpn_interface_ipsec_feature_template[iit.name].id
           version = sdwan_cisco_vpn_interface_ipsec_feature_template.cisco_vpn_interface_ipsec_feature_template[iit.name].version
           type    = "cisco_vpn_interface_ipsec"
-          sub_templates = try(iit.dhcp_server_template, null) == null ? [] : [{
+          sub_templates = flatten([
+            try(iit.dhcp_server_template, null) == null ? [] : [{
               id      = sdwan_cisco_dhcp_server_feature_template.cisco_dhcp_server_feature_template[iit.dhcp_server_template].id
               version = sdwan_cisco_dhcp_server_feature_template.cisco_dhcp_server_feature_template[iit.dhcp_server_template].version
               type    = "cisco_dhcp_server"
-            }]
+            }],
+          ])
         }],
         try(each.value.vpn_0_template.svi_interface_templates, null) == null ? [] : [for sit in try(each.value.vpn_0_template.svi_interface_templates, []) : {
           id      = sdwan_vpn_interface_svi_feature_template.vpn_interface_svi_feature_template[sit.name].id
@@ -137,7 +139,7 @@ resource "sdwan_feature_device_template" "feature_device_template" {
         }],
       ])
     }],
-    try(each.value.vpn_service_templates, null) == null ? null : [for st in try(each.value.vpn_service_templates, []) : {
+    try(each.value.vpn_service_templates, null) == null ? try([for ss in try(each.value.vpn_service_templates,[]) : null], []) : [for st in try(each.value.vpn_service_templates, []) : {
       id      = sdwan_cisco_vpn_feature_template.cisco_vpn_feature_template[st.name].id
       version = sdwan_cisco_vpn_feature_template.cisco_vpn_feature_template[st.name].version
       type    = "cisco_vpn"
@@ -152,7 +154,7 @@ resource "sdwan_feature_device_template" "feature_device_template" {
           version = sdwan_cisco_bgp_feature_template.cisco_bgp_feature_template[st.bgp_template].version
           type    = "cisco_bgp"
         }],
-        try(st.ethernet_interface_templates, null) == null ? [] : [for eit in try(st.ethernet_interface_templates, []) : [{
+        try(st.ethernet_interface_templates, null) == null ? [] : [for eit in try(st.ethernet_interface_templates, []) : {
           id      = sdwan_cisco_vpn_interface_feature_template.cisco_vpn_interface_feature_template[eit.name].id
           version = sdwan_cisco_vpn_interface_feature_template.cisco_vpn_interface_feature_template[eit.name].version
           type    = "cisco_vpn_interface"
@@ -161,8 +163,8 @@ resource "sdwan_feature_device_template" "feature_device_template" {
               version = sdwan_cisco_dhcp_server_feature_template.cisco_dhcp_server_feature_template[eit.dhcp_server_template].version
               type    = "cisco_dhcp_server"
             }]
-        }]],
-        try(st.ipsec_interface_templates, null) == null ? [] : [for iit in try(st.ipsec_interface_templates, []) : [{
+        }],
+        try(st.ipsec_interface_templates, null) == null ? [] : [for iit in try(st.ipsec_interface_templates, []) : {
           id      = sdwan_cisco_vpn_interface_ipsec_feature_template.cisco_vpn_interface_ipsec_feature_template[iit.name].id
           version = sdwan_cisco_vpn_interface_ipsec_feature_template.cisco_vpn_interface_ipsec_feature_template[iit.name].version
           type    = "cisco_vpn_interface_ipsec"
@@ -171,8 +173,8 @@ resource "sdwan_feature_device_template" "feature_device_template" {
               version = sdwan_cisco_dhcp_server_feature_template.cisco_dhcp_server_feature_template[iit.dhcp_server_template].version
               type    = "cisco_dhcp_server"
             }]
-        }]],
-        try(st.svi_interface_templates, null) == null ? [] : [for sit in try(st.svi_interface_templates, []) : [{
+        }],
+        try(st.svi_interface_templates, null) == null ? [] : [for sit in try(st.svi_interface_templates, []) : {
           id      = sdwan_vpn_interface_svi_feature_template.vpn_interface_svi_feature_template[sit.name].id
           version = sdwan_vpn_interface_svi_feature_template.vpn_interface_svi_feature_template[sit.name].version
           type    = "vpn-interface-svi"
@@ -180,8 +182,8 @@ resource "sdwan_feature_device_template" "feature_device_template" {
               id      = sdwan_cisco_dhcp_server_feature_template.cisco_dhcp_server_feature_template[sit.dhcp_server_template].id
               version = sdwan_cisco_dhcp_server_feature_template.cisco_dhcp_server_feature_template[sit.dhcp_server_template].version
               type    = "cisco_dhcp_server"
-            }]
-        }]],
+            }],
+        }],
       ])
     }],
   ])


### PR DESCRIPTION
Test Data

```yaml
---
# Edge Device template data
sdwan:
  edge_device_templates:
    - name: DT-C8000V-SINGLECPE
      description: "Test device template"
      device_model: C8000V
      aaa_template: FT-CEDGE-AAA-01
      banner_template: FT-CEDGE-BANNER-01
      bfd_template: FT-CEDGE-BFD-01
      cli_template: FT-EDGE-CLI-LOGGING
      global_settings_template: FT-CEDGE-GLOBAL-01
      localized_policy: LOCAL-POLICY-TEMPLATE-01
      logging_template: FT-CEDGE-LOGGING-01
      ntp_template: FT-CEDGE-NTP-01
      omp_template: FT-CEDGE-OMP-01
      security_template: FT-CEDGE-SECURITY-01
      snmp_template: FT-CEDGE-SNMPV3-01
      system_template: FT-CEDGE-SYSTEM-01
      vpn_0_template:
        name: FT-CEDGE-VPN0-01
        ethernet_interface_templates:
          - name: FT-CEDGE-WAN-TLOC1
          - name: FT-CEDGE-WAN-TLOC2
      vpn_512_template:
        name: FT-CEDGE-VPN512-01
        ethernet_interface_templates:
          - name: FT-CEDGE-VPN512-OOB
      switchport_templates:
        - name: FT-CEDGE-SWITCHPORT-V01
        - name: FT-CEDGE-SWITCHPORT-V02
    - name: DT-C8000V-DUALCPE-ACTIVE
      description: "Dual-CPE site, active template"
      device_model: C8000V
      aaa_template: FT-CEDGE-AAA-01
      banner_template: FT-CEDGE-BANNER-01
      bfd_template: FT-CEDGE-BFD-01
      cli_template: FT-EDGE-CLI-LOGGING
      global_settings_template: FT-CEDGE-GLOBAL-01
      localized_policy: LOCAL-POLICY-TEMPLATE-01
      logging_template: FT-CEDGE-LOGGING-01
      ntp_template: FT-CEDGE-NTP-01
      omp_template: FT-CEDGE-OMP-01
      security_template: FT-CEDGE-SECURITY-01
      snmp_template: FT-CEDGE-SNMPV3-01
      system_template: FT-CEDGE-SYSTEM-01
      vpn_0_template:
        name: FT-CEDGE-VPN0-01
        ethernet_interface_templates:
          - name: FT-CEDGE-WAN-TLOC1
          - name: FT-CEDGE-WAN-TLOC2
      vpn_service_templates:
        - name: FT-CEDGE-VPN1-ACTIVE-01
          bgp_template: FT-CEDGE-BGP-VPN1-ACTIVE
          ethernet_interface_templates:
            - name: FT-CEDGE-VPN1-LAN1
        - name: FT-CEDGE-VPN511-01
          ethernet_interface_templates:
            - name: FT-CEDGE-VPN511-LOOPBACK511
      vpn_512_template:
        name: FT-CEDGE-VPN512-01
        ethernet_interface_templates:
          - name: FT-CEDGE-VPN512-OOB
    - name: DT-C8000V-DUALCPE-STANDBY
      description: "Dual-CPE site, active template"
      device_model: C8000V
      aaa_template: FT-CEDGE-AAA-01
      banner_template: FT-CEDGE-BANNER-01
      bfd_template: FT-CEDGE-BFD-01
      cli_template: FT-EDGE-CLI-LOGGING
      global_settings_template: FT-CEDGE-GLOBAL-01
      localized_policy: LOCAL-POLICY-TEMPLATE-01
      logging_template: FT-CEDGE-LOGGING-01
      ntp_template: FT-CEDGE-NTP-01
      omp_template: FT-CEDGE-OMP-01
      security_template: FT-CEDGE-SECURITY-01
      snmp_template: FT-CEDGE-SNMPV3-01
      system_template: FT-CEDGE-SYSTEM-01
      vpn_0_template:
        name: FT-CEDGE-VPN0-01
        ethernet_interface_templates:
          - name: FT-CEDGE-WAN-TLOC1
          - name: FT-CEDGE-WAN-TLOC2
      vpn_service_templates:
        - name: FT-CEDGE-VPN1-STANDBY-01
          bgp_template: FT-CEDGE-BGP-VPN1-STANDBY
          ethernet_interface_templates:
            - name: FT-CEDGE-VPN1-LAN1
        - name: FT-CEDGE-VPN511-01
          ethernet_interface_templates:
            - name: FT-CEDGE-VPN511-LOOPBACK511
      vpn_512_template:
        name: FT-CEDGE-VPN512-01
        ethernet_interface_templates:
          - name: FT-CEDGE-VPN512-OOB
