### PR TITLE
Set device_role in device templates

### DIFF
--- a/sdwan_device_templates.tf
+++ b/sdwan_device_templates.tf
@@ -3,6 +3,7 @@ resource "sdwan_feature_device_template" "feature_device_template" {
   name           = each.value.name
   description    = each.value.description
   device_type    = try(local.device_type_map[each.value.device_model], "vedge-${each.value.device_model}")
+  device_role    = "sdwan-edge"
   policy_id      = try(each.value.localized_policy, null) == null ? null : sdwan_localized_policy.localized_policy[each.value.localized_policy].id
   policy_version = try(each.value.localized_policy, null) == null ? null : sdwan_localized_policy.localized_policy[each.value.localized_policy].version
   general_templates = flatten([


### PR DESCRIPTION
The device_role is mandatory in vManage. If not set and device template is attached to Edge, then device template cannot be edit in UI. Since we support only SD-WAN, hardcoding the value to "sdwan-edge".