### PR TITLE
modify yaml_directories lookup

### DIFF
--- a/merge.tf
+++ b/merge.tf
@@ -3,7 +3,7 @@
 locals {
   yaml_strings_directories = flatten([
     for dir in var.yaml_directories : [
-      for file in fileset(".", "${dir}/*.{yml,yaml}") : file(file)
+      for file in fileset(".", "${dir}/**/*.{yml,yaml}") : file(file)
     ]
   ])
   yaml_strings_files = [


### PR DESCRIPTION
See example folder structure:
```
data/
├── file1.yaml
├── subdir1/
│   ├── file2.yaml
│   └── subsubdir1/
│       └── file3.yaml
└── subdir2/
    └── file4.yaml
```

With current merge.tf, if yaml_directories = "./data/" then only file1.yaml is detected by merge.tf. The propose code change makes sure file1.yaml, file2.yaml, file3.yaml and file4.yaml are detected by merge.tf. This aligns to how iac validation works too.