### PR TITLE
Feature Template | Secure app hosting | add additional variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.0 (unreleased version)
+
+- Add support for variables to Secure App Hosting feature Template
+
 ## 0.1.0
 
 - Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - add support for sdwan_policy_object_mirror resource
 - add support for sdwan_policy_object_policer resource
 - add support for sdwan_policy_object_tloc_list resource
-- add support for variables to Secure App Hosting feature Template
+- add support for variables in secure app hosting feature template
 
 ## 0.1.0
 

--- a/sdwan_feature_templates.tf
+++ b/sdwan_feature_templates.tf
@@ -2004,9 +2004,12 @@ resource "sdwan_security_app_hosting_feature_template" "security_app_hosting_fea
   description  = each.value.description
   device_types = [for d in try(each.value.device_types, local.defaults.sdwan.edge_feature_templates.secure_app_hosting_templates.device_types) : try(local.device_type_map[d], "vedge-${d}")]
   virtual_applications = [{
-    nat              = try(each.value.nat, null)
-    database_url     = try(each.value.download_url_database_on_device, null)
-    resource_profile = try(each.value.resource_profile, null)
-    instance_id      = 1
+    nat                       = try(each.value.nat, null)
+    nat_variable              = try(each.value.nat_variable, null)
+    database_url              = try(each.value.download_url_database_on_device, null)
+    database_url_variable     = try(each.value.download_url_database_on_device_variable, null)
+    resource_profile          = try(each.value.resource_profile, null)
+    resource_profile_variable = try(each.value.resource_profile_variable, null)
+    instance_id               = 1
   }]
 }


### PR DESCRIPTION
Secure app hosting Feature template seems to have missed the below 3 variables. This PR addresses the gap


```
  nat_variable: regex('^[^"~`$&+,]{1,255}$', required=False)
  download_url_database_on_device_variable: regex('^[^"~`$&+,]{1,255}$', required=False)
  resource_profile_variable: regex('^[^"~`$&+,]{1,255}$', required=False)
```
