### PR TITLE
Modifying none -> None for SIG other template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - add support for service IPv4 ACL
 - add support for transport BGP
 - add support for transport IPv4 ACL
+- fix `backup_interface` to consider `none` as `None` in Secure Internet Gateway feature template
 
 ## 1.2.0
 

--- a/sdwan_feature_templates.tf
+++ b/sdwan_feature_templates.tf
@@ -855,7 +855,7 @@ resource "sdwan_cisco_secure_internet_gateway_feature_template" "cisco_secure_in
     interface_pairs = try(length(each.value.high_availability_interface_pairs) == 0, true) ? null : [for pair in try(each.value.high_availability_interface_pairs, []) : {
       active_interface        = try(pair.active_interface, null)
       active_interface_weight = try(pair.active_interface_weight, null)
-      backup_interface        = try(pair.backup_interface, null)
+      backup_interface        = try(pair.backup_interface == "none" ? "None" : pair.backup_interface, null)
       backup_interface_weight = try(pair.backup_interface_weight, null)
     }]
   }]


### PR DESCRIPTION
The SIG template in Generic mode or Other mode, in HA section the backup interface in GUI is expecting None not none. Updated that.