### PR TITLE
logging_custom_profile_update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - add support for transport IPv4 ACL
 - add support for transport OSPF
 - fix `backup_interface` to consider `none` as `None` in Secure Internet Gateway feature template
+- fix logging_feature_template `custom_profile` attribute logic (`null` in case tls_profile is not configured)
 
 ## 1.2.0
 

--- a/sdwan_feature_templates.tf
+++ b/sdwan_feature_templates.tf
@@ -531,7 +531,7 @@ resource "sdwan_cisco_logging_feature_template" "cisco_logging_feature_template"
     logging_level_variable    = try(server.logging_level_variable, null)
     source_interface          = try(server.source_interface, null)
     source_interface_variable = try(server.source_interface_variable, null)
-    custom_profile            = try(server.tls_profile, null) == null ? false : true
+    custom_profile            = try(server.tls_profile, null) == null ? null : true
     profile                   = try(server.tls_profile, null)
     profile_variable          = try(server.tls_profile_variable, null)
     optional                  = try(server.optional, null)
@@ -547,7 +547,7 @@ resource "sdwan_cisco_logging_feature_template" "cisco_logging_feature_template"
     logging_level_variable    = try(server.logging_level_variable, null)
     source_interface          = try(server.source_interface, null)
     source_interface_variable = try(server.source_interface_variable, null)
-    custom_profile            = try(server.tls_profile, null) == null ? false : true
+    custom_profile            = try(server.tls_profile, null) == null ? null : true
     profile                   = try(server.tls_profile, null)
     profile_variable          = try(server.tls_profile_variable, null)
     optional                  = try(server.optional, null)


### PR DESCRIPTION
fix logging_feature_template `custom_profile` attribute logic (`null` in case tls_profile is not configured)