### PR TITLE
update_ngfw_log_action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - add support for `dhcp_ha_enable` and `dhcp_ha_enable_variable` in DHCP server feature (`sdwan_service_dhcp_server_feature`)
 - Use Terraform provider functions for YAML merge instead of data sources (requires Terraform >= 1.8.0, previously >= 1.3.0)
 - add support for external services cloud provider credentials settings
+- fix NGFW policy `inspect` + `log` action without advanced inspection profile (missing `connectionEvents` action)
 
 ## 1.4.0
 

--- a/sdwan_features_embedded_security.tf
+++ b/sdwan_features_embedded_security.tf
@@ -117,27 +117,28 @@ resource "sdwan_embedded_security_ngfw_policy" "embedded_security_ngfw_policy" {
       # Scenario 1 — pass/drop + log: true    → [{type=log, parameter="true"}]
       # Scenario 2 — inspect + no log + AIP   → [{type=advancedInspectionProfile, parameter_id=<uuid>}]
       # Scenario 3 — inspect + log + AIP      → [{type=connectionEvents, parameter="true"}, {type=advancedInspectionProfile, parameter_id=<uuid>}]
+      # Scenario 4 — inspect + log only       → [{type=connectionEvents, parameter="true"}]
       # No action                             → null
       actions = (
         seq.base_action != "inspect"
         ? (
-          try(seq.actions.log, local.defaults.sdwan.feature_profiles.ngfw_security_profiles.policies.sequences.actions.log, false) == true
+          try(seq.actions.log, local.defaults.sdwan.feature_profiles.ngfw_security_profiles.policies.sequences.actions.log, false)
           ? [{ type = "log", parameter = "true", parameter_id = null }]
           : null
         )
         : (
-          try(seq.actions.advanced_inspection_profile, null) != null
-          ? (
-            try(seq.actions.log, local.defaults.sdwan.feature_profiles.ngfw_security_profiles.policies.sequences.actions.log, false) == true
-            ? [
-              { type = "connectionEvents", parameter = "true", parameter_id = null },
-              { type = "advancedInspectionProfile", parameter = null, parameter_id = sdwan_policy_object_unified_advanced_inspection_profile.policy_object_unified_advanced_inspection_profile[seq.actions.advanced_inspection_profile].id }
-            ]
-            : [
-              { type = "advancedInspectionProfile", parameter = null, parameter_id = sdwan_policy_object_unified_advanced_inspection_profile.policy_object_unified_advanced_inspection_profile[seq.actions.advanced_inspection_profile].id }
-            ]
+          try(seq.actions.log, local.defaults.sdwan.feature_profiles.ngfw_security_profiles.policies.sequences.actions.log, false)
+          ? concat(
+            [{ type = "connectionEvents", parameter = "true", parameter_id = null }],
+            try(seq.actions.advanced_inspection_profile, null) != null
+            ? [{ type = "advancedInspectionProfile", parameter = null, parameter_id = sdwan_policy_object_unified_advanced_inspection_profile.policy_object_unified_advanced_inspection_profile[seq.actions.advanced_inspection_profile].id }]
+            : []
           )
-          : null
+          : (
+            try(seq.actions.advanced_inspection_profile, null) != null
+            ? [{ type = "advancedInspectionProfile", parameter = null, parameter_id = sdwan_policy_object_unified_advanced_inspection_profile.policy_object_unified_advanced_inspection_profile[seq.actions.advanced_inspection_profile].id }]
+            : null
+          )
         )
       )
     }


### PR DESCRIPTION
update_ngfw_log_action to support `inspect` + `log` action without advanced inspection profile