### PR TITLE
aaa tacacs and radius group_name generation fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.5.0 (unreleased)
 
+- **BREAKING CHANGE**: system AAA TACACS/RADIUS `group_name` auto-generation format changed; name is now resolved in priority order: explicit `group_name` field → `tacacs-{index}-{vpn}` / `radius-{index}-{vpn}` (if `vpn` is set) → `tacacs-{index}-{index}` / `radius-{index}-{index}` (fallback); previously only `tacacs-{vpn}` / `radius-{vpn}` (without index) was generated (e.g. `tacacs-0-511` instead of `tacacs-511`), or set `group_name` explicitly to retain the old name
 - add support for transport WAN VPN cellular interface
 - add support for transport cellular controller
 - add support for policy object security local domain list
@@ -14,6 +15,7 @@
 - add support for referencing built-in (read-only) system data prefix lists (e.g. `rfc1918_default_dataprefixes`) and application lists (e.g. `office365_apps`) by name in service IPv4 ACL, transport IPv4 ACL, system IPv4 device access policy, and application priority traffic policy match entries
 - fix tracker in `transport WAN VPN ipsec interface`
 - allow combining `yaml_directories`/`yaml_files` with `model` variable for deep merge
+- 
 
 ## 1.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.5.0 (unreleased)
 
-- **BREAKING CHANGE**: system AAA TACACS/RADIUS `group_name` auto-generation format changed; name is now resolved in priority order: explicit `group_name` field → `tacacs-{index}-{vpn}` / `radius-{index}-{vpn}` (if `vpn` is set) → `tacacs-{index}-{index}` / `radius-{index}-{index}` (fallback); previously only `tacacs-{vpn}` / `radius-{vpn}` (without index) was generated (e.g. `tacacs-0-511` instead of `tacacs-511`), or set `group_name` explicitly to retain the old name
+- **BREAKING CHANGE**: system AAA TACACS/RADIUS `group_name` auto-generation format changed; name is now resolved in priority order: explicit `group_name` field → `tacacs-{index}-{vpn}` / `radius-{index}-{vpn}` (if `vpn` is set) → `tacacs-{index}-{index}` / `radius-{index}-{index}` (fallback); previously only `tacacs-{vpn}` / `radius-{vpn}` (without index) was generated; to avoid a breaking push when upgrading, set `group_name` explicitly to the previously auto-generated name (e.g. add `group_name: tacacs-511` for a TACACS group with `vpn: 511`) — this preserves the existing group name in Manager without any configuration change
 - add support for transport WAN VPN cellular interface
 - add support for transport cellular controller
 - add support for policy object security local domain list

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@
 - add support for referencing built-in (read-only) system data prefix lists (e.g. `rfc1918_default_dataprefixes`) and application lists (e.g. `office365_apps`) by name in service IPv4 ACL, transport IPv4 ACL, system IPv4 device access policy, and application priority traffic policy match entries
 - fix tracker in `transport WAN VPN ipsec interface`
 - allow combining `yaml_directories`/`yaml_files` with `model` variable for deep merge
-- 
 
 ## 1.4.0
 

--- a/sdwan_features_system.tf
+++ b/sdwan_features_system.tf
@@ -30,8 +30,8 @@ resource "sdwan_system_aaa_feature" "system_aaa_feature" {
     method           = rule.method
     rule_id          = rule.id
   }]
-  radius_groups = try(length(each.value.aaa.radius_groups) == 0, true) ? null : [for group in each.value.aaa.radius_groups : {
-    group_name = try("radius-${group.vpn}", "radius-0-0")
+  radius_groups = try(length(each.value.aaa.radius_groups) == 0, true) ? null : [for index, group in each.value.aaa.radius_groups : {
+    group_name = try(group.group_name, "radius-${index}-${group.vpn}", "radius-${index}-${index}")
     servers = !can(group.servers) ? null : [for server in group.servers : {
       acct_port           = try(server.accounting_port, null)
       acct_port_variable  = try("{{${server.accounting_port_variable}}}", null)
@@ -53,8 +53,8 @@ resource "sdwan_system_aaa_feature" "system_aaa_feature" {
     source_interface_variable = try("{{${group.source_interface_variable}}}", null)
   }]
   server_auth_order = try(each.value.aaa.auth_order, local.defaults.sdwan.feature_profiles.system_profiles.aaa.auth_order)
-  tacacs_groups = try(length(each.value.aaa.tacacs_groups) == 0, true) ? null : [for group in each.value.aaa.tacacs_groups : {
-    group_name = try("tacacs-${group.vpn}", "tacacs-0-0")
+  tacacs_groups = try(length(each.value.aaa.tacacs_groups) == 0, true) ? null : [for index, group in each.value.aaa.tacacs_groups : {
+    group_name = try(group.group_name, try("tacacs-${index}-${group.vpn}", "tacacs-${index}-${index}"))
     servers = !can(group.servers) ? null : [for server in group.servers : {
       address          = server.address
       key              = try(server.key, null)

--- a/sdwan_features_system.tf
+++ b/sdwan_features_system.tf
@@ -54,7 +54,7 @@ resource "sdwan_system_aaa_feature" "system_aaa_feature" {
   }]
   server_auth_order = try(each.value.aaa.auth_order, local.defaults.sdwan.feature_profiles.system_profiles.aaa.auth_order)
   tacacs_groups = try(length(each.value.aaa.tacacs_groups) == 0, true) ? null : [for index, group in each.value.aaa.tacacs_groups : {
-    group_name = try(group.group_name, try("tacacs-${index}-${group.vpn}", "tacacs-${index}-${index}"))
+    group_name = try(group.group_name, "tacacs-${index}-${group.vpn}", "tacacs-${index}-${index}")
     servers = !can(group.servers) ? null : [for server in group.servers : {
       address          = server.address
       key              = try(server.key, null)


### PR DESCRIPTION
**BREAKING CHANGE**: system AAA TACACS/RADIUS `group_name` auto-generation format changed; name is now resolved in priority order: explicit `group_name` field → `tacacs-{index}-{vpn}` / `radius-{index}-{vpn}` (if `vpn` is set) → `tacacs-{index}-{index}` / `radius-{index}-{index}` (fallback); previously only `tacacs-{vpn}` / `radius-{vpn}` (without index) was generated (e.g. `tacacs-0-511` instead of `tacacs-511`), or set `group_name` explicitly to retain the old name